### PR TITLE
Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM quay.io/cdis/alpine:3.14
+
 USER root
 
 RUN apk update && \


### PR DESCRIPTION
Resolve rate limit issue:

> Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit