### PR TITLE
(HP-2203) skip mounting license files for gen3-licensed workspace

### DIFF
--- a/sidecar.sh
+++ b/sidecar.sh
@@ -1,3 +1,6 @@
+# Environments with AL2 base images should set USER_UID=1010
+export USER_UID="${USER_UID:-1000}"
+
 function log(){
     LOGFILE="/data/populate_log.txt"
     if [[ ! -f ${LOGFILE} ]]; then
@@ -71,7 +74,7 @@ function populate() {
                 mkdir -p $FOLDER
 
                 # make sure folder can be written to by notebook
-                chown -R 1010:100 $FOLDER
+                chown -R ${USER_UID}:100 $FOLDER
 
                 if [[ "$base_dir" == "manifests" ]]; then
                     MANIFEST_FILE=$(curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" "https://$GEN3_ENDPOINT/manifests/file/$FILENAME")
@@ -130,10 +133,6 @@ function get_access_token() {
 
 function mount_hatchery_files() {
     log "Mounting Hatchery files"
-    if [[ $WORKSPACE_FLAVOR == "gen3-licensed" ]]; then
-        echo "No file mounting for 'gen3-licensed' workspace"
-        return
-    fi
     FOLDER="/data"
     if [ ! -d "$FOLDER" ]; then
         mkdir $FOLDER

--- a/sidecar.sh
+++ b/sidecar.sh
@@ -71,7 +71,7 @@ function populate() {
                 mkdir -p $FOLDER
 
                 # make sure folder can be written to by notebook
-                chown -R 1000:100 $FOLDER
+                chown -R 1010:100 $FOLDER
 
                 if [[ "$base_dir" == "manifests" ]]; then
                     MANIFEST_FILE=$(curl -s -H "Authorization: Bearer ${ACCESS_TOKEN}" "https://$GEN3_ENDPOINT/manifests/file/$FILENAME")

--- a/sidecar.sh
+++ b/sidecar.sh
@@ -130,6 +130,10 @@ function get_access_token() {
 
 function mount_hatchery_files() {
     log "Mounting Hatchery files"
+    if [[ $WORKSPACE_FLAVOR == "gen3-licensed" ]]; then
+        echo "No file mounting for 'gen3-licensed' workspace"
+        return
+    fi
     FOLDER="/data"
     if [ ! -d "$FOLDER" ]; then
         mkdir $FOLDER


### PR DESCRIPTION
JIRA ticket: [HP-2203](https://ctds-planx.atlassian.net/browse/HP-2203)

These 3 PRs should be merged and tagged around the same time:

[hatchery PR 131](https://github.com/uc-cdis/hatchery/pull/131)
  - disables stata.lic from being served by /mount-files, copies stata license from kubernetes to environment variable for gen3-licensed workspace.

[container PR 240](https://github.com/uc-cdis/containers/pull/240) 
  - the wait_for_license.sh script reads the secret from the environment variable instead of copying from the /data/ directory
  - updates base images to AL2

[sidecar PR 20](https://github.com/uc-cdis/ecs-ws-sidecar/pull/20) 
  - disables the reading of the stata license from the /mount-files endpoint (and does not copy to the /data/ directory.
  - updates the UID for compatibility with AL2
### New Features

### Breaking Changes
* Updates the UID to 1010 via an environment variable for AL2 base images

### Bug Fixes

### Improvements

* Skip mounting of stata-license for gen3-licensed workspaces

### Dependency updates

### Deployment changes
* The USER_UID environment variable can be set to 1010 for deployments that use containers with AL2 base images.


[HP-2203]: https://ctds-planx.atlassian.net/browse/HP-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ